### PR TITLE
Make Select fully controlled inputs.

### DIFF
--- a/src/components/SearchCat/SearchCatForm.jsx
+++ b/src/components/SearchCat/SearchCatForm.jsx
@@ -76,7 +76,9 @@ class SearchCatForm extends Component {
       allCategories,
       loadingCats,
       selectedCats,
-      allImageTypes
+      allImageTypes,
+      selectedCategory,
+      selectedImageTypes
     } = this.state;
 
     const { excludedCats } = this.props;
@@ -86,6 +88,7 @@ class SearchCatForm extends Component {
         <Select
           options={allCategories}
           placeholder="Category"
+          value={selectedCategory}
           onChange={selectedCategory =>
             this.setState({ selectedCategory }, this.searchCat)
           }
@@ -95,6 +98,7 @@ class SearchCatForm extends Component {
           isMulti
           options={allImageTypes}
           placeholder="Image type"
+          value={selectedImageTypes}
           onChange={selectedImageTypes =>
             this.setState({ selectedImageTypes }, this.searchCat)
           }


### PR DESCRIPTION
In React classical inputs are either uncontrolled or controlled.
Here we only overrides onChange (and not value) of Select component.

This is not very clean, therefore this commit overload value propr
using state.